### PR TITLE
Cut down on the redundancy in event names a bit

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1148,29 +1148,39 @@ bool Host::installPackage( const QString& fileName, int module )
     // reorder permanent and temporary triggers: perm first, temp second
     mTriggerUnit.reorderTriggersAfterPackageImport();
 
-    TEvent installEvent;
+    // raise 2 events - a generic one and a more detailed one to serve both
+    // a simple need ("I just want the install event") and a more specific need
+    // ("I specifically need to know when the module was synced")
+    TEvent genericInstallEvent;
+    genericInstallEvent.mArgumentList.append(QLatin1String("sysInstall"));
+    genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    genericInstallEvent.mArgumentList.append(packageName);
+    genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    raiseEvent(genericInstallEvent);
+
+    TEvent detailedInstallEvent;
     switch (module) {
     case 0:
-        installEvent.mArgumentList.append(QLatin1String("sysInstallPackage"));
+        detailedInstallEvent.mArgumentList.append(QLatin1String("sysInstallPackage"));
         break;
     case 1:
-        installEvent.mArgumentList.append(QLatin1String("sysInstallModule"));
+        detailedInstallEvent.mArgumentList.append(QLatin1String("sysInstallModule"));
         break;
     case 2:
-        installEvent.mArgumentList.append(QLatin1String("sysSyncInstallModule"));
+        detailedInstallEvent.mArgumentList.append(QLatin1String("sysSyncInstallModule"));
         break;
     case 3:
-        installEvent.mArgumentList.append(QLatin1String("sysLuaInstallModule"));
+        detailedInstallEvent.mArgumentList.append(QLatin1String("sysLuaInstallModule"));
         break;
     default:
         Q_UNREACHABLE();
     }
-    installEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    installEvent.mArgumentList.append(packageName);
-    installEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    installEvent.mArgumentList.append(fileName);
-    installEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    raiseEvent(installEvent);
+    detailedInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    detailedInstallEvent.mArgumentList.append(packageName);
+    detailedInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    detailedInstallEvent.mArgumentList.append(fileName);
+    detailedInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    raiseEvent(detailedInstallEvent);
 
     return true;
 }
@@ -1230,27 +1240,37 @@ bool Host::uninstallPackage(const QString& packageName, int module)
         }
     }
 
-    TEvent uninstallEvent;
+    // raise 2 events - a generic one and a more detailed one to serve both
+    // a simple need ("I just want the uninstall event") and a more specific need
+    // ("I specifically need to know when the module was uninstalled via Lua")
+    TEvent genericUninstallEvent;
+    genericUninstallEvent.mArgumentList.append(QLatin1String("sysUninstall"));
+    genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    genericUninstallEvent.mArgumentList.append(packageName);
+    genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    raiseEvent(genericUninstallEvent);
+
+    TEvent detailedUninstallEvent;
     switch (module) {
     case 0:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackage"));
+        detailedUninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackage"));
         break;
     case 1:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallModule"));
+        detailedUninstallEvent.mArgumentList.append(QLatin1String("sysUninstallModule"));
         break;
     case 2:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysSyncUninstallModule"));
+        detailedUninstallEvent.mArgumentList.append(QLatin1String("sysSyncUninstallModule"));
         break;
     case 3:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysLuaUninstallModule"));
+        detailedUninstallEvent.mArgumentList.append(QLatin1String("sysLuaUninstallModule"));
         break;
     default:
         Q_UNREACHABLE();
     }
-    uninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    uninstallEvent.mArgumentList.append(packageName);
-    uninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    raiseEvent(uninstallEvent);
+    detailedUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    detailedUninstallEvent.mArgumentList.append(packageName);
+    detailedUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    raiseEvent(detailedUninstallEvent);
 
     int dualInstallations=0;
     if (mInstalledModules.contains(packageName) && mInstalledPackages.contains(packageName))

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1151,16 +1151,16 @@ bool Host::installPackage( const QString& fileName, int module )
     TEvent installEvent;
     switch (module) {
     case 0:
-        installEvent.mArgumentList.append(QLatin1String("sysInstallPackageEvent"));
+        installEvent.mArgumentList.append(QLatin1String("sysInstallPackage"));
         break;
     case 1:
-        installEvent.mArgumentList.append(QLatin1String("sysInstallModuleEvent"));
+        installEvent.mArgumentList.append(QLatin1String("sysInstallModule"));
         break;
     case 2:
-        installEvent.mArgumentList.append(QLatin1String("sysSyncInstallModuleEvent"));
+        installEvent.mArgumentList.append(QLatin1String("sysSyncInstallModule"));
         break;
     case 3:
-        installEvent.mArgumentList.append(QLatin1String("sysLuaInstallModuleEvent"));
+        installEvent.mArgumentList.append(QLatin1String("sysLuaInstallModule"));
         break;
     default:
         Q_UNREACHABLE();
@@ -1233,16 +1233,16 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     TEvent uninstallEvent;
     switch (module) {
     case 0:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackageEvent"));
+        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackage"));
         break;
     case 1:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallModuleEvent"));
+        uninstallEvent.mArgumentList.append(QLatin1String("sysUninstallModule"));
         break;
     case 2:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysSyncUninstallModuleEvent"));
+        uninstallEvent.mArgumentList.append(QLatin1String("sysSyncUninstallModule"));
         break;
     case 3:
-        uninstallEvent.mArgumentList.append(QLatin1String("sysLuaUninstallModuleEvent"));
+        uninstallEvent.mArgumentList.append(QLatin1String("sysLuaUninstallModule"));
         break;
     default:
         Q_UNREACHABLE();


### PR DESCRIPTION
We have a mix "Event" suffix with and without right now: http://wiki.mudlet.org/w/Manual:Event_Engine and I'd be a fan of keeping them short instead of getting into unnecessary-long Java-like names. They're events already, they can't be anything else since they're in the event system that handles only events. It's like calling it an ATM machine, if you get what I mean?