### PR TITLE
Add setTitle resetTitle to Geyser Mapper

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -80,6 +80,16 @@ function Geyser.Mapper:setDockPosition(pos)
   end
 end
 
+function Geyser.Mapper:setTitle(text)
+  self.titleText = text
+  return setMapWindowTitle(text)
+end
+
+function Geyser.Mapper:resetTitle()
+  self.titleText = ""
+  return resetMapWindowTitle()
+end
+
 -- Overridden constructor
 function Geyser.Mapper:new (cons, container)
   cons = cons or {}
@@ -114,6 +124,12 @@ function Geyser.Mapper:new (cons, container)
       me:get_width(), me:get_height())
     else
       openMapWidget()
+    end
+
+    if me.titleText then
+      me:setTitle(me.titleText)
+    else
+      me:resetTitle()
     end
   end
 


### PR DESCRIPTION
As mentioned in https://github.com/Mudlet/Mudlet/pull/3609
This adds the Geyser functionality.

The mapper needs to be a Map Window which means embedded needs to be false at creation

Geyser.Mapper:
myMapper:setTitle(string text)
myMapper:resetTitle()

Variable to setTitle at creation:
titleText = "my custom title" -- has no default value

for example:
```lua
myMapper = Geyser.Mapper:new({embedded = false, titleText = "my new mapper"})
```

