### PR TITLE
put update dimensions in activateProfile

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4368,6 +4368,7 @@ void mudlet::activateProfile(Host* pHost)
         }
         mpCurrentActiveHost = pHost;
         dactionInputLine->setChecked(mpCurrentActiveHost->getCompactInputLine());
+        pHost->updateDisplayDimensions();
     }
 }
 


### PR DESCRIPTION
Not sure if this is ideal spot, but this seems to trigger the NAWS message when clicking into the other input box while in multiview mode.