### PR TITLE
Fix distro packages showing dev icon

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -158,7 +158,8 @@ mudlet::mudlet()
             }
         }
 #else
-        mBuildType = BuildType::NotUpdateable;
+        // Distro packages without updater: still use Release type for empty app-build.txt
+        mBuildType = mAppBuild.isEmpty() ? BuildType::Release : BuildType::NotUpdateable;
 #endif
     } else {
         qWarning().nospace().noquote() << "mudlet::mudlet() WARNING - failed to open app-build.txt for reading: " << gitShaFile.errorString();


### PR DESCRIPTION
When INCLUDE_UPDATER is not defined, check mAppBuild.isEmpty() to determine if this is a release build. This preserves the existing behavior where releaseVersion = mAppBuild.isEmpty() is independent of whether the updater is compiled in.
