### PR TITLE
Fix: getKeyCode test improvements

### DIFF
--- a/src/mudlet-lua/tests/KeyBinds_spec.lua
+++ b/src/mudlet-lua/tests/KeyBinds_spec.lua
@@ -2,130 +2,82 @@ describe("Tests keybind-related functions", function()
 
   describe("Tests the functionality of getKeyCode", function()
 
-    -- Note: These tests require actual keybinds to exist in the test environment
-    -- The following tests demonstrate the expected behavior
-
     setup(function()
-      -- Create test keybinds for testing
-      -- testKeyID will hold the ID of a test keybind
-      _G.testKeyName = "TestKeyBind_" .. os.time()
-      _G.testKeyID = nil
-
-      -- Attempt to create a test keybind
-      -- Using permKey to create a permanent keybind for testing
-      -- permKey(name, parent, modifier, key code, lua code)
-      if permKey then
-        _G.testKeyID = permKey(_G.testKeyName, "", mudlet.keymodifier.Control, mudlet.key.F1, [[echo("Test key pressed")]])
-      end
+      -- tempKey creates temporary keybinds that killKey can actually remove
+      -- tempKey(modifier, key code, lua code)
+      _G.testKeyID = tempKey(mudlet.keymodifier.Control, mudlet.key.F1, [[echo("Test key pressed")]])
     end)
 
     teardown(function()
-      -- Clean up test keybind
-      if _G.testKeyID and killKey then
+      if _G.testKeyID then
         killKey(_G.testKeyID)
       end
-      _G.testKeyName = nil
       _G.testKeyID = nil
     end)
 
-    it("should return key code and modifiers for a valid keybind by name", function()
-      -- Skip if we couldn't create a test keybind
-      if not _G.testKeyID then
-        pending("permKey function not available in test environment")
-        return
-      end
-
-      local keyCode, modifiers = getKeyCode(_G.testKeyName)
-
-      -- Verify we got two return values
-      assert.is_not_nil(keyCode, "Expected keyCode to be returned")
-      assert.is_not_nil(modifiers, "Expected modifiers to be returned")
-
-      -- Verify the values match what we set
-      assert.equals(mudlet.key.F1, keyCode, "Expected key code to match F1")
-      assert.equals(mudlet.keymodifier.Control, modifiers, "Expected modifiers to include Control")
-    end)
-
     it("should return key code and modifiers for a valid keybind by ID", function()
-      -- Skip if we couldn't create a test keybind
-      if not _G.testKeyID then
-        pending("permKey function not available in test environment")
-        return
-      end
-
       local keyCode, modifiers = getKeyCode(_G.testKeyID)
 
-      -- Verify we got two return values
       assert.is_not_nil(keyCode, "Expected keyCode to be returned")
       assert.is_not_nil(modifiers, "Expected modifiers to be returned")
-
-      -- Verify the values match what we set
       assert.equals(mudlet.key.F1, keyCode, "Expected key code to match F1")
       assert.equals(mudlet.keymodifier.Control, modifiers, "Expected modifiers to include Control")
     end)
 
     it("should return nil and error message for non-existent keybind name", function()
       local nonExistentName = "NonExistentKeyBind_" .. os.time()
-      local keyCode, modifiers = getKeyCode(nonExistentName)
+      local keyCode, errorMsg = getKeyCode(nonExistentName)
 
-      -- Function should return nil on error
       assert.is_nil(keyCode, "Expected nil for non-existent keybind")
+      assert.is_string(errorMsg, "Expected error message string")
     end)
 
     it("should return nil and error message for non-existent keybind ID", function()
       local nonExistentID = 999999
-      local keyCode, modifiers = getKeyCode(nonExistentID)
+      local keyCode, errorMsg = getKeyCode(nonExistentID)
 
-      -- Function should return nil on error
       assert.is_nil(keyCode, "Expected nil for non-existent keybind ID")
+      assert.is_string(errorMsg, "Expected error message string")
     end)
 
     it("should return nil and error message for invalid ID (negative number)", function()
       local invalidID = -1
-      local keyCode, modifiers = getKeyCode(invalidID)
+      local keyCode, errorMsg = getKeyCode(invalidID)
 
-      -- Function should return nil on error
       assert.is_nil(keyCode, "Expected nil for invalid negative ID")
+      assert.is_string(errorMsg, "Expected error message string")
     end)
 
-    it("should accept both string and number types for the first argument", function()
-      -- Skip if we couldn't create a test keybind
-      if not _G.testKeyID then
-        pending("permKey function not available in test environment")
-        return
-      end
+    it("should raise an error if called with no arguments", function()
+      assert.has_error(function()
+        getKeyCode()
+      end)
+    end)
 
-      -- Test with string (name)
-      local keyCode1, modifiers1 = getKeyCode(_G.testKeyName)
-      assert.is_not_nil(keyCode1, "Expected result when passing string name")
+    it("should raise an error if called with a boolean argument", function()
+      assert.has_error(function()
+        getKeyCode(true)
+      end)
+    end)
 
-      -- Test with number (ID)
-      local keyCode2, modifiers2 = getKeyCode(_G.testKeyID)
-      assert.is_not_nil(keyCode2, "Expected result when passing numeric ID")
+    it("should raise an error if called with a table argument", function()
+      assert.has_error(function()
+        getKeyCode({})
+      end)
+    end)
 
-      -- Both should return the same values
-      assert.equals(keyCode1, keyCode2, "Key codes should match when querying same keybind")
-      assert.equals(modifiers1, modifiers2, "Modifiers should match when querying same keybind")
+    it("should raise an error if called with a nil argument", function()
+      assert.has_error(function()
+        getKeyCode(nil)
+      end)
     end)
 
     it("should work with keybinds that have no modifiers", function()
-      -- Create a keybind with no modifiers (NoModifier)
-      local testKeyName2 = "TestKeyBind_NoMod_" .. os.time()
-      local testKeyID2 = nil
+      local testKeyID2 = tempKey(mudlet.keymodifier.None, mudlet.key.F2, [[echo("Test")]])
 
-      if permKey then
-        testKeyID2 = permKey(testKeyName2, "", mudlet.keymodifier.None, mudlet.key.F2, [[echo("Test")]])
-      else
-        pending("permKey function not available in test environment")
-        return
-      end
+      local keyCode, modifiers = getKeyCode(testKeyID2)
 
-      local keyCode, modifiers = getKeyCode(testKeyName2)
-
-      -- Clean up
-      if testKeyID2 and killKey then
-        killKey(testKeyID2)
-      end
+      killKey(testKeyID2)
 
       assert.is_not_nil(keyCode, "Expected keyCode to be returned")
       assert.equals(mudlet.key.F2, keyCode, "Expected key code to match F2")
@@ -133,31 +85,15 @@ describe("Tests keybind-related functions", function()
     end)
 
     it("should work with keybinds that have multiple modifiers", function()
-      -- Create a keybind with multiple modifiers (Ctrl + Shift)
-      local testKeyName3 = "TestKeyBind_MultiMod_" .. os.time()
-      local testKeyID3 = nil
+      local multiMod = mudlet.keymodifier.Control + mudlet.keymodifier.Shift
+      local testKeyID3 = tempKey(multiMod, mudlet.key.F3, [[echo("Test")]])
 
-      if permKey then
-        -- Combine modifiers using bitwise OR
-        local multiMod = mudlet.keymodifier.Control + mudlet.keymodifier.Shift
-        testKeyID3 = permKey(testKeyName3, "", multiMod, mudlet.key.F3, [[echo("Test")]])
-      else
-        pending("permKey function not available in test environment")
-        return
-      end
+      local keyCode, modifiers = getKeyCode(testKeyID3)
 
-      local keyCode, modifiers = getKeyCode(testKeyName3)
-
-      -- Clean up
-      if testKeyID3 and killKey then
-        killKey(testKeyID3)
-      end
+      killKey(testKeyID3)
 
       assert.is_not_nil(keyCode, "Expected keyCode to be returned")
       assert.equals(mudlet.key.F3, keyCode, "Expected key code to match F3")
-
-      -- Check that the modifiers contain both Control and Shift
-      -- In Qt, modifiers are flags that can be combined
       local expectedMod = mudlet.keymodifier.Control + mudlet.keymodifier.Shift
       assert.equals(expectedMod, modifiers, "Expected Control + Shift modifiers")
     end)


### PR DESCRIPTION
Addresses the test file issues identified in the [review of PR #8435](https://github.com/Mudlet/Mudlet/pull/8435#issuecomment-2779282953):

- **Use `tempKey` instead of `permKey`** for test fixtures so `killKey()` can actually clean them up. `permKey` creates permanent keybinds that `killKey()` refuses to remove, and the name/ID mismatch meant cleanup never worked
- **Add `assert.has_error` tests** for invalid argument types: no arguments, boolean, table, and nil - covering the `getVerifiedStringOrInteger` → `lua_error` code path
- **Check the error message return value** in error-case tests (renamed variable from `modifiers` to `errorMsg` for clarity) and assert it's a string
- **Remove unnecessary `if not _G.testKeyID then pending() end` guards** since `tempKey`/`permKey` are always available in the Mudlet test environment